### PR TITLE
Add configurable ZIP folder structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,10 +207,12 @@ export default function App() {
                 </div>
               )}
 
-              <FolderStructurePicker
-                value={folderStructure}
-                onChange={setFolderStructure}
-              />
+              <div className="w-full max-w-md">
+                <FolderStructurePicker
+                  value={folderStructure}
+                  onChange={setFolderStructure}
+                />
+              </div>
 
               <div className="w-full max-w-md">
                 <Button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { DatabaseInfo } from "./components/DatabaseInfo";
 import { ErrorAlert } from "./components/ErrorAlert";
 import { FolderInput } from "./components/FolderInput";
 import { FolderStructureGuide } from "./components/FolderStructureGuide";
+import { FolderStructurePicker } from "./components/FolderStructurePicker";
 import { Gallery } from "./components/Gallery";
 import { Spinner } from "./components/Spinner";
 import { ThemeToggle } from "./components/ThemeToggle";
@@ -47,6 +48,8 @@ export default function App() {
     selectedFileCount,
     selectedSizeBytes,
     totalFileCount,
+    folderStructure,
+    setFolderStructure,
     processFiles,
     downloadZip,
     toggleGame,
@@ -204,6 +207,11 @@ export default function App() {
                 </div>
               )}
 
+              <FolderStructurePicker
+                value={folderStructure}
+                onChange={setFolderStructure}
+              />
+
               <div className="w-full max-w-md">
                 <Button
                   onClick={downloadZip}
@@ -215,9 +223,6 @@ export default function App() {
                     ? `Download ZIP (${selectedFileCount} files)`
                     : "Select games to download"}
                 </Button>
-                <p className="mt-2.5 text-sm text-stone-400 dark:text-slate-500 text-center">
-                  Organized by game with correct dates
-                </p>
               </div>
 
               <FolderInput

--- a/src/components/DatabaseInfo.tsx
+++ b/src/components/DatabaseInfo.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import { useClickOutside } from "../hooks";
 import { loadCaptureIdsMetadata } from "../utils/captureIds";
 import type { CaptureIdsMetadata } from "../types";
 
@@ -36,28 +37,14 @@ export function DatabaseInfo() {
   const [isExpanded, setIsExpanded] = useState(false);
   const [error, setError] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const collapse = useCallback(() => setIsExpanded(false), []);
+  useClickOutside(containerRef, isExpanded, collapse);
 
   useEffect(() => {
     loadCaptureIdsMetadata()
       .then(setMetadata)
       .catch(() => setError(true));
   }, []);
-
-  useEffect(() => {
-    if (!isExpanded) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setIsExpanded(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isExpanded]);
 
   if (error || !metadata) {
     return null;

--- a/src/components/FolderStructurePicker.tsx
+++ b/src/components/FolderStructurePicker.tsx
@@ -1,0 +1,72 @@
+import type { FolderStructure } from "../types";
+
+const OPTIONS: { value: FolderStructure; label: string; example: string }[] = [
+  {
+    value: "by-game",
+    label: "By game",
+    example: "Zelda TOTK/screenshot.jpg",
+  },
+  {
+    value: "by-date",
+    label: "By date",
+    example: "2024/March/screenshot.jpg",
+  },
+  {
+    value: "by-game-date",
+    label: "Game + date",
+    example: "Zelda TOTK/2024-03/screenshot.jpg",
+  },
+  {
+    value: "flat-renamed",
+    label: "Flat renamed",
+    example: "Zelda TOTK - 2024-03-15 14.30.00.jpg",
+  },
+];
+
+interface FolderStructurePickerProps {
+  value: FolderStructure;
+  onChange: (value: FolderStructure) => void;
+}
+
+export function FolderStructurePicker({
+  value,
+  onChange,
+}: FolderStructurePickerProps) {
+  return (
+    <div className="w-full max-w-md">
+      <p className="text-xs font-medium text-stone-500 dark:text-slate-400 mb-2">
+        Folder structure
+      </p>
+      <div className="grid grid-cols-2 gap-2">
+        {OPTIONS.map((option) => {
+          const isSelected = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              className={`text-left px-3 py-2.5 rounded-xl border transition-all duration-150 cursor-pointer ${
+                isSelected
+                  ? "border-nx/50 bg-nx/5 dark:bg-nx/10 ring-1 ring-nx/20"
+                  : "border-stone-200/50 dark:border-slate-700/30 bg-stone-50 dark:bg-slate-800/50 hover:bg-stone-100 dark:hover:bg-slate-800"
+              }`}
+            >
+              <span
+                className={`text-sm font-medium block ${
+                  isSelected
+                    ? "text-nx"
+                    : "text-stone-700 dark:text-slate-300"
+                }`}
+              >
+                {option.label}
+              </span>
+              <span className="text-[11px] text-stone-400 dark:text-slate-500 block mt-0.5 truncate">
+                {option.example}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FolderStructurePicker.tsx
+++ b/src/components/FolderStructurePicker.tsx
@@ -1,10 +1,13 @@
+import { useCallback, useRef, useState } from "react";
+import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/24/solid";
+import { useClickOutside } from "../hooks";
 import type { FolderStructure } from "../types";
 
 const OPTIONS: { value: FolderStructure; label: string; example: string }[] = [
   {
     value: "by-game",
     label: "By game",
-    example: "Zelda TOTK/screenshot.jpg",
+    example: "Game Name/screenshot.jpg",
   },
   {
     value: "by-date",
@@ -14,12 +17,12 @@ const OPTIONS: { value: FolderStructure; label: string; example: string }[] = [
   {
     value: "by-game-date",
     label: "Game + date",
-    example: "Zelda TOTK/2024-03/screenshot.jpg",
+    example: "Game Name/2024-03/screenshot.jpg",
   },
   {
     value: "flat-renamed",
     label: "Flat renamed",
-    example: "Zelda TOTK - 2024-03-15 14.30.00.jpg",
+    example: "Game Name - 2024-03-15 14.30.00.jpg",
   },
 ];
 
@@ -32,41 +35,72 @@ export function FolderStructurePicker({
   value,
   onChange,
 }: FolderStructurePickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useClickOutside(ref, open, close);
+  const selected = OPTIONS.find((o) => o.value === value)!;
+
   return (
-    <div className="w-full max-w-md">
-      <p className="text-xs font-medium text-stone-500 dark:text-slate-400 mb-2">
-        Folder structure
-      </p>
-      <div className="grid grid-cols-2 gap-2">
-        {OPTIONS.map((option) => {
-          const isSelected = value === option.value;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => onChange(option.value)}
-              className={`text-left px-3 py-2.5 rounded-xl border transition-all duration-150 cursor-pointer ${
-                isSelected
-                  ? "border-nx/50 bg-nx/5 dark:bg-nx/10 ring-1 ring-nx/20"
-                  : "border-stone-200/50 dark:border-slate-700/30 bg-stone-50 dark:bg-slate-800/50 hover:bg-stone-100 dark:hover:bg-slate-800"
-              }`}
-            >
-              <span
-                className={`text-sm font-medium block ${
+    <div className="relative w-full" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="w-full flex items-center justify-between gap-2 px-3.5 py-2.5 rounded-xl border border-stone-200 dark:border-slate-700 bg-stone-50 dark:bg-slate-800/50 hover:bg-stone-100 dark:hover:bg-slate-800 transition-colors duration-150 cursor-pointer"
+      >
+        <div className="min-w-0 text-left">
+          <span className="text-xs text-stone-400 dark:text-slate-500 block leading-tight">
+            Folder structure
+          </span>
+          <span className="text-sm font-medium text-stone-700 dark:text-slate-300 block truncate">
+            {selected.label}
+          </span>
+        </div>
+        <ChevronUpDownIcon className="w-4 h-4 text-stone-400 dark:text-slate-500 shrink-0" />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 right-0 bottom-full mb-1.5 rounded-xl border border-stone-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-xl dark:shadow-black/40 overflow-hidden z-50">
+          {OPTIONS.map((option) => {
+            const isSelected = value === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 flex items-start gap-2.5 transition-colors duration-100 cursor-pointer ${
                   isSelected
-                    ? "text-nx"
-                    : "text-stone-700 dark:text-slate-300"
+                    ? "bg-nx/5 dark:bg-nx/10"
+                    : "hover:bg-stone-50 dark:hover:bg-slate-700/50"
                 }`}
               >
-                {option.label}
-              </span>
-              <span className="text-[11px] text-stone-400 dark:text-slate-500 block mt-0.5 truncate">
-                {option.example}
-              </span>
-            </button>
-          );
-        })}
-      </div>
+                <CheckIcon
+                  className={`w-4 h-4 mt-0.5 shrink-0 transition-opacity ${
+                    isSelected ? "text-nx opacity-100" : "opacity-0"
+                  }`}
+                />
+                <div className="min-w-0">
+                  <span
+                    className={`text-sm font-medium block ${
+                      isSelected
+                        ? "text-nx"
+                        : "text-stone-700 dark:text-slate-300"
+                    }`}
+                  >
+                    {option.label}
+                  </span>
+                  <span className="text-[11px] text-stone-400 dark:text-slate-500 block truncate">
+                    {option.example}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,22 @@ export const VALIDATION = {
   MAX_SECOND: 59,
 } as const;
 
+// Month names for folder-structure formatting
+export const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
 // Default values
 export const DEFAULTS = {
   UNKNOWN_GAME_NAME: "Unknown",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useClickOutside } from "./useClickOutside";
 export { useTheme } from "./useTheme";
 export { useDropZone } from "./useDropZone";
 export { useScreenshotProcessor } from "./useScreenshotProcessor";

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect, type RefObject } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean,
+  onClose: () => void
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [ref, enabled, onClose]);
+}

--- a/src/hooks/useScreenshotProcessor.ts
+++ b/src/hooks/useScreenshotProcessor.ts
@@ -3,10 +3,11 @@ import { filterSwitchScreenshots } from "../utils/filesystem";
 import {
   parseScreenshotFilename,
   groupFilesByGame,
+  getZipPath,
 } from "../utils/screenshot";
 import { loadCaptureIds } from "../utils/captureIds";
 import { createZip, type ZipProgress } from "../utils/zip";
-import type { CaptureIds, GameGroup } from "../types";
+import type { CaptureIds, FolderStructure, GameGroup, Screenshot } from "../types";
 
 export type ProcessorStatus =
   | "idle"
@@ -40,6 +41,8 @@ export function useScreenshotProcessor() {
 
   const [gameGroups, setGameGroups] = useState<GameGroup[]>([]);
   const [selectedGames, setSelectedGames] = useState<Set<string>>(new Set());
+  const [folderStructure, setFolderStructure] =
+    useState<FolderStructure>("by-game");
 
   // Track current operation to prevent race conditions
   const currentOperationId = useRef(0);
@@ -175,9 +178,13 @@ export function useScreenshotProcessor() {
       const parseWithCaptureIds = (filename: string) =>
         parseScreenshotFilename(filename, captureIdsRef.current);
 
+      const pathGenerator = (screenshot: Screenshot, originalFilename: string) =>
+        getZipPath(screenshot, originalFilename, folderStructure);
+
       const filename = await createZip(
         filesToExport,
         parseWithCaptureIds,
+        pathGenerator,
         handleProgress
       );
       setState((prev) => ({
@@ -261,6 +268,8 @@ export function useScreenshotProcessor() {
     totalFileCount,
     gameGroups,
     selectedGames,
+    folderStructure,
+    setFolderStructure,
     processFiles,
     downloadZip,
     toggleGame,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,12 @@ export interface SourceMetadata {
   sourceUpdatedAt: string | null;
 }
 
+export type FolderStructure =
+  | "by-game"
+  | "by-date"
+  | "by-game-date"
+  | "flat-renamed";
+
 export interface CaptureIdsMetadata {
   totalCount: number;
   generatedAt: string;

--- a/src/utils/screenshot.ts
+++ b/src/utils/screenshot.ts
@@ -1,5 +1,11 @@
-import type { Screenshot, CaptureIds, GameGroup, ParsedFile } from "../types";
-import { FILENAME, VALIDATION, DEFAULTS } from "../constants";
+import type {
+  Screenshot,
+  CaptureIds,
+  GameGroup,
+  ParsedFile,
+  FolderStructure,
+} from "../types";
+import { FILENAME, VALIDATION, DEFAULTS, MONTH_NAMES } from "../constants";
 
 /**
  * Parse a Nintendo Switch screenshot/video filename into its components.
@@ -68,6 +74,30 @@ export function parseScreenshotFilename(
     captureId,
     gameName: captureIds?.[captureId] ?? DEFAULTS.UNKNOWN_GAME_NAME,
   };
+}
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Generate the ZIP path for a file based on the selected folder structure.
+ */
+export function getZipPath(
+  screenshot: Screenshot,
+  originalFilename: string,
+  structure: FolderStructure
+): string {
+  switch (structure) {
+    case "by-game":
+      return `${screenshot.gameName}/${originalFilename}`;
+    case "by-date":
+      return `${screenshot.year}/${MONTH_NAMES[screenshot.month]}/${originalFilename}`;
+    case "by-game-date":
+      return `${screenshot.gameName}/${screenshot.year}-${pad2(screenshot.month + 1)}/${originalFilename}`;
+    case "flat-renamed": {
+      const ext = originalFilename.substring(originalFilename.lastIndexOf("."));
+      return `${screenshot.gameName} - ${screenshot.year}-${pad2(screenshot.month + 1)}-${pad2(screenshot.day)} ${pad2(screenshot.hour)}.${pad2(screenshot.minute)}.${pad2(screenshot.second)}${ext}`;
+    }
+  }
 }
 
 /**

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -42,6 +42,55 @@ export function isSafari(): boolean {
   return ua.includes("Safari") && !ua.includes("Chrome") && !ua.includes("Chromium");
 }
 
+/**
+ * Ensure a zip path is unique by appending a counter suffix if needed.
+ */
+function deduplicatePath(path: string, usedPaths: Set<string>): string {
+  if (!usedPaths.has(path)) {
+    usedPaths.add(path);
+    return path;
+  }
+  // Split on last slash to isolate the filename, so dots in directory names are ignored
+  const lastSlash = path.lastIndexOf("/");
+  const dir = lastSlash >= 0 ? path.substring(0, lastSlash + 1) : "";
+  const filename = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+  const dotIdx = filename.lastIndexOf(".");
+  const base = dotIdx >= 0 ? filename.substring(0, dotIdx) : filename;
+  const ext = dotIdx >= 0 ? filename.substring(dotIdx) : "";
+  let counter = 2;
+  let candidate: string;
+  do {
+    candidate = `${dir}${base} (${counter})${ext}`;
+    counter++;
+  } while (usedPaths.has(candidate));
+  usedPaths.add(candidate);
+  return candidate;
+}
+
+/**
+ * Read a file, parse its screenshot metadata, and add it to the zip archive.
+ */
+async function addFileToZip(
+  zip: Zip,
+  file: File,
+  parseFilename: (filename: string) => Screenshot,
+  getPath: (screenshot: Screenshot, filename: string) => string,
+  usedPaths: Set<string>
+): Promise<void> {
+  const screenshot = parseFilename(file.name);
+  const arrayBuffer = await file.arrayBuffer();
+  const data = new Uint8Array(arrayBuffer);
+
+  const zipPath = deduplicatePath(getPath(screenshot, file.name), usedPaths);
+  const fileDate = screenshotToDate(screenshot);
+
+  const zipFile = new ZipPassThrough(zipPath);
+  zipFile.mtime = fileDate;
+
+  zip.add(zipFile);
+  zipFile.push(data, true);
+}
+
 interface WritableStreamResult {
   stream: WritableStream<Uint8Array>;
   filename: string;
@@ -91,6 +140,7 @@ function createStreamSaverWritableStream(): WritableStreamResult {
 async function createZipWithBlobDownload(
   files: File[],
   parseFilename: (filename: string) => Screenshot,
+  getPath: (screenshot: Screenshot, filename: string) => string,
   onProgress?: ProgressCallback
 ): Promise<string> {
   const filename = DEFAULTS.ZIP_FILENAME;
@@ -99,6 +149,7 @@ async function createZipWithBlobDownload(
   // Collect all chunks in memory
   const chunks: Uint8Array[] = [];
   let error: Error | null = null;
+  const usedPaths = new Set<string>();
 
   const zip = new Zip((err, chunk, _final) => {
     if (err) {
@@ -117,19 +168,7 @@ async function createZipWithBlobDownload(
     const file = files[i];
     if (!file) continue;
 
-    const screenshot = parseFilename(file.name);
-    const arrayBuffer = await file.arrayBuffer();
-    const data = new Uint8Array(arrayBuffer);
-
-    const zipPath = `${screenshot.gameName}/${file.name}`;
-    const fileDate = screenshotToDate(screenshot);
-
-    // Create file entry with date (no compression for images/videos)
-    const zipFile = new ZipPassThrough(zipPath);
-    zipFile.mtime = fileDate;
-
-    zip.add(zipFile);
-    zipFile.push(data, true);
+    await addFileToZip(zip, file, parseFilename, getPath, usedPaths);
 
     onProgress?.({ current: i + 1, total, phase: "processing" });
   }
@@ -169,11 +208,12 @@ async function createZipWithBlobDownload(
 export async function createZip(
   files: File[],
   parseFilename: (filename: string) => Screenshot,
+  getPath: (screenshot: Screenshot, filename: string) => string,
   onProgress?: ProgressCallback
 ): Promise<string> {
   // Safari doesn't support StreamSaver.js properly, use Blob download
   if (isSafari()) {
-    return createZipWithBlobDownload(files, parseFilename, onProgress);
+    return createZipWithBlobDownload(files, parseFilename, getPath, onProgress);
   }
 
   // Choose between native API (Chromium) and StreamSaver.js (Firefox)
@@ -189,6 +229,7 @@ export async function createZip(
   // Collect chunks synchronously, flush after each file
   let pendingChunks: Uint8Array[] = [];
   let error: Error | null = null;
+  const usedPaths = new Set<string>();
 
   const zip = new Zip((err, chunk, _final) => {
     if (err) {
@@ -218,19 +259,7 @@ export async function createZip(
       const file = files[i];
       if (!file) continue;
 
-      const screenshot = parseFilename(file.name);
-      const arrayBuffer = await file.arrayBuffer();
-      const data = new Uint8Array(arrayBuffer);
-
-      const zipPath = `${screenshot.gameName}/${file.name}`;
-      const fileDate = screenshotToDate(screenshot);
-
-      // Create file entry with date (no compression for images/videos)
-      const zipFile = new ZipPassThrough(zipPath);
-      zipFile.mtime = fileDate;
-
-      zip.add(zipFile);
-      zipFile.push(data, true); // true = final chunk for this file
+      await addFileToZip(zip, file, parseFilename, getPath, usedPaths);
 
       // Flush after each file to keep memory low
       await flushPending();


### PR DESCRIPTION
## Summary
- Adds a folder structure picker with 4 options: by game, by date, game + date, and flat renamed
- Generates ZIP paths based on the selected structure via `getZipPath()`
- Deduplicates colliding paths with a counter suffix (e.g. `file (2).jpg`)
- Consolidates duplicated zip-file-adding logic into a shared `addFileToZip()` helper

## Test plan
- [ ] Select screenshots and verify each of the 4 folder structure options produces the correct ZIP layout
- [ ] Verify the default "By game" option matches the previous behavior
- [ ] Test with games that have identical timestamps to confirm path deduplication works
- [ ] Test on Safari (blob download path) and Chrome/Firefox (streaming path)