### PR TITLE
Add hover slideshow to GameCard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,11 +163,11 @@ export default function App() {
           </div>
         )}
 
-        {/* Gallery State */}
-        {isGalleryView && (
+        {/* Gallery State — kept mounted to preserve thumbnail cache */}
+        {gameGroups.length > 0 && (
           <div
-            className="w-full max-w-6xl animate-fade-up"
-            style={{ animationDelay: "0.1s" }}
+            className={`w-full max-w-6xl ${isGalleryView ? "animate-fade-up" : "hidden"}`}
+            style={isGalleryView ? { animationDelay: "0.1s" } : undefined}
           >
             {error && <ErrorAlert message={error} className="mb-4" />}
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -91,21 +91,18 @@ export function Gallery({
         )}
       </div>
 
-      {/* Content */}
-      {tab === "gallery" ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-          {gameGroups.map((group) => (
-            <GameCard
-              key={group.gameName}
-              group={group}
-              selected={selectedGames.has(group.gameName)}
-              onToggle={() => onToggleGame(group.gameName)}
-            />
-          ))}
-        </div>
-      ) : (
-        <CollectionStats gameGroups={gameGroups} />
-      )}
+      {/* Content — gallery grid stays mounted to preserve thumbnail cache */}
+      <div className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 ${tab !== "gallery" ? "hidden" : ""}`}>
+        {gameGroups.map((group) => (
+          <GameCard
+            key={group.gameName}
+            group={group}
+            selected={selectedGames.has(group.gameName)}
+            onToggle={() => onToggleGame(group.gameName)}
+          />
+        ))}
+      </div>
+      {tab === "stats" && <CollectionStats gameGroups={gameGroups} />}
     </div>
   );
 }

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -4,6 +4,21 @@ import type { GameGroup } from "../types";
 import { IMAGE_EXT, VIDEO_EXT } from "../constants";
 
 const SLIDESHOW_INTERVAL = 1500;
+const VIDEO_PREVIEW_DURATION = 5000;
+const CROSSFADE_MS = 150;
+const SUPPORTS_RVFC =
+  typeof HTMLVideoElement !== "undefined" &&
+  "requestVideoFrameCallback" in HTMLVideoElement.prototype;
+
+let _snapshotCanvas: HTMLCanvasElement | null = null;
+function snapshotVideoFrame(video: HTMLVideoElement): string | null {
+  if (!video.videoWidth) return null;
+  if (!_snapshotCanvas) _snapshotCanvas = document.createElement("canvas");
+  _snapshotCanvas.width = video.videoWidth;
+  _snapshotCanvas.height = video.videoHeight;
+  _snapshotCanvas.getContext("2d")!.drawImage(video, 0, 0);
+  return _snapshotCanvas.toDataURL("image/jpeg", 0.85);
+}
 
 interface GameCardProps {
   group: GameGroup;
@@ -95,15 +110,25 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
   const [isHovering, setIsHovering] = useState(false);
   const [slideIndex, setSlideIndex] = useState(0);
   const [slideUrl, setSlideUrl] = useState<string | null>(null);
+  const [slideLoaded, setSlideLoaded] = useState(false);
+  const [prevSnapshotUrl, setPrevSnapshotUrl] = useState<string | null>(null);
   const slideUrlRef = useRef<string | null>(null);
+  const prevBlobUrlRef = useRef<string | null>(null);
+  const currentIsVideoRef = useRef(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const fileCount = group.files.length;
 
-  const revokeSlideUrl = useCallback(() => {
+  const revokeAll = useCallback(() => {
     if (slideUrlRef.current) {
       URL.revokeObjectURL(slideUrlRef.current);
       slideUrlRef.current = null;
+    }
+    if (prevBlobUrlRef.current) {
+      URL.revokeObjectURL(prevBlobUrlRef.current);
+      prevBlobUrlRef.current = null;
     }
   }, []);
 
@@ -113,10 +138,12 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
 
   useEffect(() => {
     if (!isHovering || fileCount === 0) {
-      revokeSlideUrl();
+      revokeAll();
       setSlideUrl(null);
+      setPrevSnapshotUrl(null);
       setSlideIndex(0);
       clearTimeout(timerRef.current);
+      clearTimeout(fadeTimerRef.current);
       return;
     }
 
@@ -124,30 +151,82 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
     if (!file) return;
     const isVideo = file.file.name.endsWith(VIDEO_EXT);
 
-    revokeSlideUrl();
+    // Snapshot outgoing slide to hold it visible during the transition
+    if (prevBlobUrlRef.current) {
+      URL.revokeObjectURL(prevBlobUrlRef.current);
+      prevBlobUrlRef.current = null;
+    }
+    if (slideUrlRef.current) {
+      if (currentIsVideoRef.current && videoRef.current) {
+        // Capture the video's displayed frame — renders instantly as <img>
+        setPrevSnapshotUrl(snapshotVideoFrame(videoRef.current));
+        URL.revokeObjectURL(slideUrlRef.current);
+      } else {
+        // Outgoing is an image — reuse its blob URL
+        prevBlobUrlRef.current = slideUrlRef.current;
+        setPrevSnapshotUrl(slideUrlRef.current);
+      }
+    }
+
     const url = URL.createObjectURL(file.file);
     slideUrlRef.current = url;
+    currentIsVideoRef.current = isVideo;
+    setSlideLoaded(false);
     setSlideUrl(url);
 
-    if (!isVideo && fileCount > 1) {
-      timerRef.current = setTimeout(advanceSlide, SLIDESHOW_INTERVAL);
+    if (fileCount > 1) {
+      timerRef.current = setTimeout(advanceSlide, isVideo ? VIDEO_PREVIEW_DURATION : SLIDESHOW_INTERVAL);
     }
 
     return () => {
       clearTimeout(timerRef.current);
-      revokeSlideUrl();
     };
-  }, [isHovering, slideIndex, group.files, fileCount, revokeSlideUrl, advanceSlide]);
+  }, [isHovering, slideIndex, group.files, fileCount, revokeAll, advanceSlide]);
+
+  // Final cleanup on unmount (the main effect cleanup only clears the timer
+  // so that outgoing slide URLs survive between transitions)
+  useEffect(() => {
+    return () => {
+      clearTimeout(fadeTimerRef.current);
+      revokeAll();
+    };
+  }, [revokeAll]);
+
+  const handleSlideReady = useCallback(() => {
+    setSlideLoaded(true);
+    // Keep snapshot visible during the CSS crossfade, then clean up
+    clearTimeout(fadeTimerRef.current);
+    const blobUrl = prevBlobUrlRef.current;
+    prevBlobUrlRef.current = null;
+    fadeTimerRef.current = setTimeout(() => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+      setPrevSnapshotUrl(null);
+    }, CROSSFADE_MS);
+  }, []);
+
+  const handleVideoRef = useCallback(
+    (el: HTMLVideoElement | null) => {
+      videoRef.current = el;
+      if (el && SUPPORTS_RVFC) {
+        el.requestVideoFrameCallback(handleSlideReady);
+      }
+    },
+    [handleSlideReady],
+  );
 
   const handleVideoEnded = useCallback(() => {
-    if (fileCount > 1) advanceSlide();
+    if (fileCount > 1) {
+      clearTimeout(timerRef.current);
+      advanceSlide();
+    }
   }, [fileCount, advanceSlide]);
 
   const handleMouseEnter = useCallback(() => setIsHovering(true), []);
   const handleMouseLeave = useCallback(() => setIsHovering(false), []);
 
-  const slideIsVideo = slideUrl != null && group.files[slideIndex]?.file.name.endsWith(VIDEO_EXT);
-  const mediaClass = "w-full h-full object-cover absolute inset-0 z-[1]";
+  const slideIsVideo = slideUrl != null && currentIsVideoRef.current;
+  const mediaClass = `w-full h-full object-cover absolute inset-0 z-[1] ${prevSnapshotUrl ? "transition-opacity duration-150" : ""} ${slideLoaded ? "opacity-100" : "opacity-0"}`;
+  const prevMediaClass = "w-full h-full object-cover absolute inset-0 z-[1] pointer-events-none";
 
   return (
     <button
@@ -163,17 +242,24 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
     >
       {/* Thumbnail / Slideshow */}
       <div className="aspect-video bg-stone-100 dark:bg-slate-800/80 relative overflow-hidden">
-        {/* Slideshow layer (on hover) */}
+        {/* Previous slide snapshot (holds during transition to prevent flash) */}
+        {isHovering && prevSnapshotUrl && (
+          <img src={prevSnapshotUrl} alt="" className={prevMediaClass} />
+        )}
+
+        {/* Current slide */}
         {isHovering && slideUrl && (
           slideIsVideo ? (
             <video
               key={slideUrl}
+              ref={handleVideoRef}
               src={slideUrl}
               className={mediaClass}
               autoPlay
               muted
               playsInline
               onEnded={handleVideoEnded}
+              onLoadedData={SUPPORTS_RVFC ? undefined : handleSlideReady}
             />
           ) : (
             <img
@@ -181,6 +267,7 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
               src={slideUrl}
               alt=""
               className={mediaClass}
+              onLoad={handleSlideReady}
             />
           )
         )}

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -1,7 +1,9 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CheckIcon, VideoCameraIcon } from "@heroicons/react/24/solid";
 import type { GameGroup } from "../types";
 import { IMAGE_EXT, VIDEO_EXT } from "../constants";
+
+const SLIDESHOW_INTERVAL = 1500;
 
 interface GameCardProps {
   group: GameGroup;
@@ -89,18 +91,101 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
     };
   }, [thumbnailSource]);
 
+  // --- Hover slideshow ---
+  const [isHovering, setIsHovering] = useState(false);
+  const [slideIndex, setSlideIndex] = useState(0);
+  const [slideUrl, setSlideUrl] = useState<string | null>(null);
+  const slideUrlRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const fileCount = group.files.length;
+
+  const revokeSlideUrl = useCallback(() => {
+    if (slideUrlRef.current) {
+      URL.revokeObjectURL(slideUrlRef.current);
+      slideUrlRef.current = null;
+    }
+  }, []);
+
+  const advanceSlide = useCallback(() => {
+    setSlideIndex((prev) => (prev + 1) % fileCount);
+  }, [fileCount]);
+
+  useEffect(() => {
+    if (!isHovering || fileCount === 0) {
+      revokeSlideUrl();
+      setSlideUrl(null);
+      setSlideIndex(0);
+      clearTimeout(timerRef.current);
+      return;
+    }
+
+    const file = group.files[slideIndex];
+    if (!file) return;
+    const isVideo = file.file.name.endsWith(VIDEO_EXT);
+
+    revokeSlideUrl();
+    const url = URL.createObjectURL(file.file);
+    slideUrlRef.current = url;
+    setSlideUrl(url);
+
+    if (!isVideo && fileCount > 1) {
+      timerRef.current = setTimeout(advanceSlide, SLIDESHOW_INTERVAL);
+    }
+
+    return () => {
+      clearTimeout(timerRef.current);
+      revokeSlideUrl();
+    };
+  }, [isHovering, slideIndex, group.files, fileCount, revokeSlideUrl, advanceSlide]);
+
+  const handleVideoEnded = useCallback(() => {
+    if (fileCount > 1) advanceSlide();
+  }, [fileCount, advanceSlide]);
+
+  const handleMouseEnter = useCallback(() => setIsHovering(true), []);
+  const handleMouseLeave = useCallback(() => setIsHovering(false), []);
+
+  const slideIsVideo = slideUrl != null && group.files[slideIndex]?.file.name.endsWith(VIDEO_EXT);
+  const mediaClass = "w-full h-full object-cover absolute inset-0 z-[1]";
+
   return (
     <button
       type="button"
       onClick={onToggle}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       className={`relative rounded-xl overflow-hidden text-left transition-all duration-200 cursor-pointer bg-white dark:bg-[#161b22] hover:shadow-lg focus-visible:outline-2 focus-visible:outline-nx active:scale-[0.98] ${
         selected
           ? "ring-2 ring-nx shadow-md shadow-nx/10"
           : "ring-1 ring-stone-200/80 dark:ring-slate-700/50 opacity-50 hover:opacity-75"
       }`}
     >
-      {/* Thumbnail */}
+      {/* Thumbnail / Slideshow */}
       <div className="aspect-video bg-stone-100 dark:bg-slate-800/80 relative overflow-hidden">
+        {/* Slideshow layer (on hover) */}
+        {isHovering && slideUrl && (
+          slideIsVideo ? (
+            <video
+              key={slideUrl}
+              src={slideUrl}
+              className={mediaClass}
+              autoPlay
+              muted
+              playsInline
+              onEnded={handleVideoEnded}
+            />
+          ) : (
+            <img
+              key={slideUrl}
+              src={slideUrl}
+              alt=""
+              className={mediaClass}
+            />
+          )
+        )}
+
+        {/* Default thumbnail */}
         {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
@@ -114,9 +199,23 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
           </div>
         )}
 
+        {/* Slideshow dots (up to 12 files) */}
+        {isHovering && fileCount > 1 && fileCount <= 12 && (
+          <div className="absolute bottom-1.5 left-1/2 -translate-x-1/2 flex gap-1 z-[2]">
+            {group.files.map((_, i) => (
+              <div
+                key={i}
+                className={`w-1 h-1 rounded-full transition-colors ${
+                  i === slideIndex ? "bg-white" : "bg-white/40"
+                }`}
+              />
+            ))}
+          </div>
+        )}
+
         {/* Checkbox overlay */}
         <div
-          className={`absolute top-2 right-2 w-5 h-5 rounded flex items-center justify-center transition-colors ${
+          className={`absolute top-2 right-2 w-5 h-5 rounded flex items-center justify-center transition-colors z-[2] ${
             selected
               ? "bg-nx text-white shadow-sm"
               : "bg-white/80 dark:bg-[#161b22]/80 border border-stone-300 dark:border-slate-600"


### PR DESCRIPTION
## Summary
- Cycles through a game's screenshots and videos on hover with auto-advance (1.5s for images, play-to-end for videos)
- Shows dot indicators for games with 2-12 files
- Properly revokes object URLs on unmount to prevent memory leaks
- Derives media type at render time instead of storing redundant state

## Test plan
- [ ] Hover over a game card with multiple screenshots — images should cycle every 1.5s
- [ ] Hover over a game card with videos — video should autoplay muted and advance on end
- [ ] Verify dot indicators appear for games with 2-12 files, hidden for 1 or 13+
- [ ] Move mouse away — slideshow should stop and reset to thumbnail
- [ ] Check no object URL leaks in DevTools Memory tab after repeated hover/unhover