### PR TITLE
Add collection stats view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,20 +17,12 @@ import { Gallery } from "./components/Gallery";
 import { Spinner } from "./components/Spinner";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useScreenshotProcessor, useDropZone } from "./hooks";
+import { formatSize } from "./utils/format";
 import { isSafari } from "./utils/zip";
 
 // Safari warning threshold: 500MB
 const SAFARI_SIZE_WARNING_THRESHOLD = 500 * 1024 * 1024;
 const IS_SAFARI = isSafari();
-
-// Format bytes to human readable string
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
 
 export default function App() {
   const {

--- a/src/components/CollectionStats.tsx
+++ b/src/components/CollectionStats.tsx
@@ -1,0 +1,343 @@
+import { useMemo } from "react";
+import {
+  CameraIcon,
+  FilmIcon,
+  PhotoIcon,
+  CalendarIcon,
+  CircleStackIcon,
+  TrophyIcon,
+  FireIcon,
+  SparklesIcon,
+} from "@heroicons/react/24/solid";
+import type { GameGroup } from "../types";
+import { formatDate, formatSize } from "../utils/format";
+import { computeStats } from "../utils/stats";
+
+interface CollectionStatsProps {
+  gameGroups: GameGroup[];
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-stone-50 dark:bg-slate-800/50 border border-stone-200/50 dark:border-slate-700/30">
+      <div className="p-2 rounded-lg bg-white dark:bg-slate-700/50 text-nx shrink-0">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs text-stone-400 dark:text-slate-500 font-medium uppercase tracking-wider">
+          {label}
+        </p>
+        <p className="text-xl font-bold text-stone-800 dark:text-slate-100 font-display tracking-tight">
+          {value}
+        </p>
+        {sub && (
+          <p className="text-xs text-stone-400 dark:text-slate-500 mt-0.5">
+            {sub}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({
+  icon,
+  title,
+}: {
+  icon: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 mb-3">
+      <span className="text-nx">{icon}</span>
+      <h3 className="text-sm font-semibold text-stone-700 dark:text-slate-300 uppercase tracking-wider">
+        {title}
+      </h3>
+    </div>
+  );
+}
+
+function GameBar({
+  gameName,
+  count,
+  maxCount,
+  size,
+  rank,
+}: {
+  gameName: string;
+  count: number;
+  maxCount: number;
+  size: number;
+  rank: number;
+}) {
+  const pct = (count / maxCount) * 100;
+  return (
+    <div className="group">
+      <div className="flex items-center justify-between mb-1 gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xs font-mono text-stone-300 dark:text-slate-600 w-5 text-right shrink-0">
+            {rank}
+          </span>
+          <span className="text-sm text-stone-700 dark:text-slate-300 truncate font-medium">
+            {gameName}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs text-stone-400 dark:text-slate-500 font-mono">
+            {formatSize(size)}
+          </span>
+          <span className="text-sm font-semibold text-stone-600 dark:text-slate-400 font-mono w-10 text-right">
+            {count}
+          </span>
+        </div>
+      </div>
+      <div className="h-2 bg-stone-100 dark:bg-slate-800 rounded-full overflow-hidden ml-7">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-nx to-red-400 transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TimelineBar({
+  label,
+  count,
+  maxCount,
+  isMax,
+}: {
+  label: string;
+  count: number;
+  maxCount: number;
+  isMax: boolean;
+}) {
+  const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
+  return (
+    <div className="flex flex-col items-center gap-1 flex-1 min-w-0">
+      <span className="text-xs font-mono text-stone-500 dark:text-slate-400 font-semibold">
+        {count}
+      </span>
+      <div className="w-full h-24 bg-stone-100 dark:bg-slate-800 rounded-t-md relative flex items-end overflow-hidden">
+        <div
+          className={`w-full rounded-t-md transition-all duration-500 ${
+            isMax
+              ? "bg-gradient-to-t from-nx to-red-400"
+              : "bg-stone-300 dark:bg-slate-600"
+          }`}
+          style={{ height: `${Math.max(pct, 4)}%` }}
+        />
+      </div>
+      <span
+        className="text-[10px] text-stone-400 dark:text-slate-500 truncate w-full text-center"
+        title={label}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function MediaSplit({
+  images,
+  videos,
+}: {
+  images: number;
+  videos: number;
+}) {
+  const total = images + videos;
+  if (total === 0) return null;
+  const imgPct = (images / total) * 100;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="h-3 flex-1 rounded-full overflow-hidden flex bg-stone-100 dark:bg-slate-800">
+          <div
+            className="bg-gradient-to-r from-nx to-red-400 transition-all duration-500"
+            style={{ width: `${imgPct}%` }}
+          />
+          <div
+            className="bg-gradient-to-r from-stone-400 to-stone-300 dark:from-slate-500 dark:to-slate-600 transition-all duration-500"
+            style={{ width: `${100 - imgPct}%` }}
+          />
+        </div>
+      </div>
+      <div className="flex justify-between text-sm">
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-nx" />
+          <PhotoIcon className="w-4 h-4 text-stone-400 dark:text-slate-500" />
+          <span className="text-stone-600 dark:text-slate-400">
+            {images.toLocaleString()} screenshot{images !== 1 ? "s" : ""}
+          </span>
+          <span className="text-stone-400 dark:text-slate-500 font-mono text-xs">
+            ({Math.round(imgPct)}%)
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-stone-400 dark:bg-slate-500" />
+          <FilmIcon className="w-4 h-4 text-stone-400 dark:text-slate-500" />
+          <span className="text-stone-600 dark:text-slate-400">
+            {videos.toLocaleString()} video{videos !== 1 ? "s" : ""}
+          </span>
+          <span className="text-stone-400 dark:text-slate-500 font-mono text-xs">
+            ({Math.round(100 - imgPct)}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const MAX_GAMES_SHOWN = 15;
+const MAX_TIMELINE_MONTHS = 24;
+
+export function CollectionStats({ gameGroups }: CollectionStatsProps) {
+  const stats = useMemo(() => computeStats(gameGroups), [gameGroups]);
+
+  const topGames = stats.gameStats.slice(0, MAX_GAMES_SHOWN);
+  const remainingGames = stats.gameStats.length - MAX_GAMES_SHOWN;
+  const maxGameCount = topGames[0]?.totalFiles ?? 0;
+
+  // For timeline, show up to 24 months; if more, show last 24
+  const timelineSlice =
+    stats.timeline.length > MAX_TIMELINE_MONTHS
+      ? stats.timeline.slice(-MAX_TIMELINE_MONTHS)
+      : stats.timeline;
+  const maxMonthCount = Math.max(...timelineSlice.map((m) => m.count), 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Hero header */}
+      <div className="text-center py-2">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-nx/10 dark:bg-nx/20 text-nx text-sm font-semibold mb-3">
+          <SparklesIcon className="w-4 h-4" />
+          Your Switch in Review
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <StatCard
+          icon={<CameraIcon className="w-5 h-5" />}
+          label="Total Captures"
+          value={stats.totalFiles.toLocaleString()}
+          sub={`${stats.averageCapturesPerGame} avg per game`}
+        />
+        <StatCard
+          icon={<CircleStackIcon className="w-5 h-5" />}
+          label="Total Size"
+          value={formatSize(stats.totalSize)}
+        />
+        <StatCard
+          icon={<CalendarIcon className="w-5 h-5" />}
+          label="Date Range"
+          value={
+            stats.firstCapture && stats.lastCapture
+              ? formatDate(stats.firstCapture)
+              : "—"
+          }
+          sub={
+            stats.lastCapture
+              ? `to ${formatDate(stats.lastCapture)}`
+              : undefined
+          }
+        />
+        <StatCard
+          icon={<TrophyIcon className="w-5 h-5" />}
+          label="Most Captured"
+          value={stats.topGame?.gameName ?? "—"}
+          sub={
+            stats.topGame
+              ? `${stats.topGame.totalFiles} captures`
+              : undefined
+          }
+        />
+      </div>
+
+      {/* Media split */}
+      <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
+        <SectionHeader
+          icon={<PhotoIcon className="w-4 h-4" />}
+          title="Screenshots vs Videos"
+        />
+        <MediaSplit images={stats.totalImages} videos={stats.totalVideos} />
+      </div>
+
+      {/* Top games */}
+      <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
+        <SectionHeader
+          icon={<TrophyIcon className="w-4 h-4" />}
+          title={`Top Games (${stats.totalGames} total)`}
+        />
+        <div className="space-y-3">
+          {topGames.map((game, i) => (
+            <GameBar
+              key={game.gameName}
+              gameName={game.gameName}
+              count={game.totalFiles}
+              maxCount={maxGameCount}
+              size={game.totalSize}
+              rank={i + 1}
+            />
+          ))}
+          {remainingGames > 0 && (
+            <p className="text-xs text-stone-400 dark:text-slate-500 text-center pt-1">
+              and {remainingGames} more game{remainingGames !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Timeline */}
+      {timelineSlice.length > 1 && (
+        <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
+          <SectionHeader
+            icon={<FireIcon className="w-4 h-4" />}
+            title="Capture Timeline"
+          />
+          {stats.busiestMonth && (
+            <p className="text-xs text-stone-400 dark:text-slate-500 mb-3">
+              Peak:{" "}
+              <span className="font-semibold text-stone-600 dark:text-slate-300">
+                {stats.busiestMonth.label}
+              </span>{" "}
+              with {stats.busiestMonth.count} captures
+            </p>
+          )}
+          <div className="flex gap-1 overflow-x-auto pb-1">
+            {timelineSlice.map((m) => (
+              <TimelineBar
+                key={`${m.year}-${m.month}`}
+                label={m.label}
+                count={m.count}
+                maxCount={maxMonthCount}
+                isMax={
+                  stats.busiestMonth !== null &&
+                  m.year === stats.busiestMonth.year &&
+                  m.month === stats.busiestMonth.month
+                }
+              />
+            ))}
+          </div>
+          {stats.timeline.length > MAX_TIMELINE_MONTHS && (
+            <p className="text-xs text-stone-400 dark:text-slate-500 text-center mt-2">
+              Showing last {MAX_TIMELINE_MONTHS} months of{" "}
+              {stats.timeline.length}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CollectionStats.tsx
+++ b/src/components/CollectionStats.tsx
@@ -7,11 +7,12 @@ import {
   CircleStackIcon,
   TrophyIcon,
   FireIcon,
+  ClockIcon,
   SparklesIcon,
 } from "@heroicons/react/24/solid";
 import type { GameGroup } from "../types";
 import { formatDate, formatSize } from "../utils/format";
-import { computeStats } from "../utils/stats";
+import { computeStats, type GameStat } from "../utils/stats";
 
 interface CollectionStatsProps {
   gameGroups: GameGroup[];
@@ -29,8 +30,8 @@ function StatCard({
   sub?: string;
 }) {
   return (
-    <div className="flex items-start gap-3 p-4 rounded-xl bg-stone-50 dark:bg-slate-800/50 border border-stone-200/50 dark:border-slate-700/30">
-      <div className="p-2 rounded-lg bg-white dark:bg-slate-700/50 text-nx shrink-0">
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-white dark:bg-slate-800/60 border border-stone-200/80 dark:border-slate-700/40 shadow-sm dark:shadow-black/10">
+      <div className="p-2 rounded-lg bg-stone-50 dark:bg-slate-700/60 text-nx shrink-0">
         {icon}
       </div>
       <div className="min-w-0">
@@ -50,62 +51,108 @@ function StatCard({
   );
 }
 
-function SectionHeader({
+function SectionCard({
   icon,
   title,
+  children,
+  delay,
 }: {
   icon: React.ReactNode;
   title: string;
+  children: React.ReactNode;
+  delay: number;
 }) {
   return (
-    <div className="flex items-center gap-2 mb-3">
-      <span className="text-nx">{icon}</span>
-      <h3 className="text-sm font-semibold text-stone-700 dark:text-slate-300 uppercase tracking-wider">
-        {title}
-      </h3>
+    <div
+      className="p-5 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50 shadow-sm dark:shadow-black/10 animate-fade-up"
+      style={{ animationDelay: `${delay}s` }}
+    >
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-nx">{icon}</span>
+        <h3 className="text-sm font-semibold text-stone-700 dark:text-slate-300 uppercase tracking-wider">
+          {title}
+        </h3>
+      </div>
+      {children}
     </div>
   );
 }
 
+const RANK_STYLES: Record<number, string> = {
+  1: "text-amber-500 dark:text-amber-400 font-bold",
+  2: "text-stone-400 dark:text-slate-400 font-bold",
+  3: "text-amber-700 dark:text-amber-600 font-bold",
+};
+
 function GameBar({
-  gameName,
-  count,
+  game,
   maxCount,
-  size,
   rank,
 }: {
-  gameName: string;
-  count: number;
+  game: GameStat;
   maxCount: number;
-  size: number;
   rank: number;
 }) {
-  const pct = (count / maxCount) * 100;
+  const { gameName, totalFiles, totalSize, imageCount, videoCount } = game;
+  const pct = (totalFiles / maxCount) * 100;
+  const isTop3 = rank <= 3;
+  const imgPct = totalFiles > 0 ? (imageCount / totalFiles) * pct : 0;
+  const vidPct = pct - imgPct;
   return (
     <div className="group">
       <div className="flex items-center justify-between mb-1 gap-2">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="text-xs font-mono text-stone-300 dark:text-slate-600 w-5 text-right shrink-0">
+          <span
+            className={`text-xs font-mono w-5 text-right shrink-0 ${
+              RANK_STYLES[rank] ?? "text-stone-300 dark:text-slate-600"
+            }`}
+          >
             {rank}
           </span>
-          <span className="text-sm text-stone-700 dark:text-slate-300 truncate font-medium">
+          <span
+            className={`text-sm truncate ${
+              isTop3
+                ? "text-stone-800 dark:text-slate-200 font-semibold"
+                : "text-stone-600 dark:text-slate-400 font-medium"
+            }`}
+          >
             {gameName}
           </span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <span className="text-xs text-stone-400 dark:text-slate-500 font-mono">
-            {formatSize(size)}
+          <span className="text-xs text-stone-400 dark:text-slate-500 font-mono hidden sm:inline">
+            {formatSize(totalSize)}
           </span>
           <span className="text-sm font-semibold text-stone-600 dark:text-slate-400 font-mono w-10 text-right">
-            {count}
+            {totalFiles}
           </span>
         </div>
       </div>
-      <div className="h-2 bg-stone-100 dark:bg-slate-800 rounded-full overflow-hidden ml-7">
+      <div className="h-2 bg-stone-100 dark:bg-slate-800 rounded-full overflow-hidden ml-7 flex">
         <div
-          className="h-full rounded-full bg-gradient-to-r from-nx to-red-400 transition-all duration-500"
-          style={{ width: `${pct}%` }}
+          className={`h-full transition-all duration-500 ${
+            imgPct > 0 ? "rounded-l-full" : ""
+          } ${
+            vidPct === 0 ? "rounded-r-full" : ""
+          } ${
+            isTop3
+              ? "bg-gradient-to-r from-nx to-red-400"
+              : "bg-gradient-to-r from-stone-300 to-stone-200 dark:from-slate-600 dark:to-slate-700"
+          }`}
+          style={{ width: `${imgPct}%` }}
         />
+        {videoCount > 0 && (
+          <div
+            className={`h-full transition-all duration-500 ${
+              imgPct === 0 ? "rounded-l-full" : ""
+            } rounded-r-full ${
+              isTop3
+                ? "bg-gradient-to-r from-blue-400 to-blue-300 dark:from-blue-500 dark:to-blue-600"
+                : "bg-gradient-to-r from-blue-300 to-blue-200 dark:from-blue-700 dark:to-blue-800"
+            }`}
+            style={{ width: `${vidPct}%` }}
+          />
+        )}
       </div>
     </div>
   );
@@ -124,22 +171,35 @@ function TimelineBar({
 }) {
   const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
   return (
-    <div className="flex flex-col items-center gap-1 flex-1 min-w-0">
-      <span className="text-xs font-mono text-stone-500 dark:text-slate-400 font-semibold">
+    <div
+      className="flex flex-col items-center gap-1 min-w-[2rem]"
+      title={`${label}: ${count} captures`}
+    >
+      <span
+        className={`text-[10px] font-mono tabular-nums ${
+          isMax
+            ? "text-nx font-bold"
+            : "text-stone-400 dark:text-slate-500"
+        }`}
+      >
         {count}
       </span>
-      <div className="w-full h-24 bg-stone-100 dark:bg-slate-800 rounded-t-md relative flex items-end overflow-hidden">
+      <div className="w-full h-20 bg-stone-100 dark:bg-slate-800/80 rounded-md relative flex items-end overflow-hidden">
         <div
-          className={`w-full rounded-t-md transition-all duration-500 ${
+          className={`w-full rounded-md transition-all duration-500 ${
             isMax
               ? "bg-gradient-to-t from-nx to-red-400"
-              : "bg-stone-300 dark:bg-slate-600"
+              : "bg-nx/20 dark:bg-nx/15"
           }`}
           style={{ height: `${Math.max(pct, 4)}%` }}
         />
       </div>
       <span
-        className="text-[10px] text-stone-400 dark:text-slate-500 truncate w-full text-center"
+        className={`text-[10px] truncate w-full text-center ${
+          isMax
+            ? "text-nx font-semibold"
+            : "text-stone-400 dark:text-slate-500"
+        }`}
         title={label}
       >
         {label}
@@ -161,21 +221,19 @@ function MediaSplit({
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-2">
-        <div className="h-3 flex-1 rounded-full overflow-hidden flex bg-stone-100 dark:bg-slate-800">
-          <div
-            className="bg-gradient-to-r from-nx to-red-400 transition-all duration-500"
-            style={{ width: `${imgPct}%` }}
-          />
-          <div
-            className="bg-gradient-to-r from-stone-400 to-stone-300 dark:from-slate-500 dark:to-slate-600 transition-all duration-500"
-            style={{ width: `${100 - imgPct}%` }}
-          />
-        </div>
+      <div className="h-4 flex rounded-full overflow-hidden bg-stone-100 dark:bg-slate-800 mb-3">
+        <div
+          className="bg-gradient-to-r from-nx to-red-400 transition-all duration-500"
+          style={{ width: `${imgPct}%` }}
+        />
+        <div
+          className="bg-gradient-to-r from-blue-400 to-blue-300 dark:from-blue-500 dark:to-blue-600 transition-all duration-500"
+          style={{ width: `${100 - imgPct}%` }}
+        />
       </div>
-      <div className="flex justify-between text-sm">
+      <div className="flex flex-col sm:flex-row sm:justify-between gap-2 text-sm">
         <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-nx" />
+          <div className="w-2.5 h-2.5 rounded-full bg-nx shrink-0" />
           <PhotoIcon className="w-4 h-4 text-stone-400 dark:text-slate-500" />
           <span className="text-stone-600 dark:text-slate-400">
             {images.toLocaleString()} screenshot{images !== 1 ? "s" : ""}
@@ -185,7 +243,7 @@ function MediaSplit({
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full bg-stone-400 dark:bg-slate-500" />
+          <div className="w-2.5 h-2.5 rounded-full bg-blue-400 dark:bg-blue-500 shrink-0" />
           <FilmIcon className="w-4 h-4 text-stone-400 dark:text-slate-500" />
           <span className="text-stone-600 dark:text-slate-400">
             {videos.toLocaleString()} video{videos !== 1 ? "s" : ""}
@@ -199,6 +257,40 @@ function MediaSplit({
   );
 }
 
+function FunFactCard({
+  title,
+  value,
+  sub,
+}: {
+  title: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="p-3 rounded-lg bg-stone-50 dark:bg-slate-800/50 border border-stone-200/50 dark:border-slate-700/30">
+      <p className="text-xs text-stone-400 dark:text-slate-500 font-medium uppercase tracking-wider mb-1">
+        {title}
+      </p>
+      <p className="text-sm font-semibold text-stone-800 dark:text-slate-200">
+        {value}
+      </p>
+      <p className="text-xs text-stone-400 dark:text-slate-500 mt-0.5">
+        {sub}
+      </p>
+    </div>
+  );
+}
+
+const TIME_PERIODS = [
+  { label: "Morning", range: "6am \u2013 12pm", start: 6, end: 12 },
+  { label: "Afternoon", range: "12pm \u2013 6pm", start: 12, end: 18 },
+  { label: "Evening", range: "6pm \u2013 12am", start: 18, end: 24 },
+  { label: "Night", range: "12am \u2013 6am", start: 0, end: 6 },
+];
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0]; // Mon–Sun from getDay() indices
+
 const MAX_GAMES_SHOWN = 15;
 const MAX_TIMELINE_MONTHS = 24;
 
@@ -209,25 +301,31 @@ export function CollectionStats({ gameGroups }: CollectionStatsProps) {
   const remainingGames = stats.gameStats.length - MAX_GAMES_SHOWN;
   const maxGameCount = topGames[0]?.totalFiles ?? 0;
 
-  // For timeline, show up to 24 months; if more, show last 24
   const timelineSlice =
     stats.timeline.length > MAX_TIMELINE_MONTHS
       ? stats.timeline.slice(-MAX_TIMELINE_MONTHS)
       : stats.timeline;
   const maxMonthCount = Math.max(...timelineSlice.map((m) => m.count), 0);
 
-  return (
-    <div className="space-y-6">
-      {/* Hero header */}
-      <div className="text-center py-2">
-        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-nx/10 dark:bg-nx/20 text-nx text-sm font-semibold mb-3">
-          <SparklesIcon className="w-4 h-4" />
-          Your Switch in Review
-        </div>
-      </div>
+  const timePeriodCounts = TIME_PERIODS.map((p) => {
+    let count = 0;
+    for (let h = p.start; h < p.end; h++) count += stats.hourDistribution[h]!;
+    return count;
+  });
+  const maxTimePeriod = Math.max(...timePeriodCounts);
 
+  const dowCounts = DAY_ORDER.map((i) => stats.dayOfWeekDistribution[i]!);
+  const maxDow = Math.max(...dowCounts);
+
+  const { funFacts } = stats;
+
+  return (
+    <div className="space-y-5">
       {/* Summary cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <div
+        className="grid grid-cols-2 lg:grid-cols-4 gap-3 animate-fade-up"
+        style={{ animationDelay: "0.05s" }}
+      >
         <StatCard
           icon={<CameraIcon className="w-5 h-5" />}
           label="Total Captures"
@@ -245,7 +343,7 @@ export function CollectionStats({ gameGroups }: CollectionStatsProps) {
           value={
             stats.firstCapture && stats.lastCapture
               ? formatDate(stats.firstCapture)
-              : "—"
+              : "\u2014"
           }
           sub={
             stats.lastCapture
@@ -256,7 +354,7 @@ export function CollectionStats({ gameGroups }: CollectionStatsProps) {
         <StatCard
           icon={<TrophyIcon className="w-5 h-5" />}
           label="Most Captured"
-          value={stats.topGame?.gameName ?? "—"}
+          value={stats.topGame?.gameName ?? "\u2014"}
           sub={
             stats.topGame
               ? `${stats.topGame.totalFiles} captures`
@@ -266,67 +364,61 @@ export function CollectionStats({ gameGroups }: CollectionStatsProps) {
       </div>
 
       {/* Media split */}
-      <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
-        <SectionHeader
-          icon={<PhotoIcon className="w-4 h-4" />}
-          title="Screenshots vs Videos"
-        />
+      <SectionCard
+        icon={<PhotoIcon className="w-4 h-4" />}
+        title="Screenshots vs Videos"
+        delay={0.1}
+      >
         <MediaSplit images={stats.totalImages} videos={stats.totalVideos} />
-      </div>
+      </SectionCard>
 
       {/* Top games */}
-      <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
-        <SectionHeader
-          icon={<TrophyIcon className="w-4 h-4" />}
-          title={`Top Games (${stats.totalGames} total)`}
-        />
+      <SectionCard
+        icon={<TrophyIcon className="w-4 h-4" />}
+        title={`Top Games (${stats.totalGames} total)`}
+        delay={0.15}
+      >
         <div className="space-y-3">
           {topGames.map((game, i) => (
             <GameBar
               key={game.gameName}
-              gameName={game.gameName}
-              count={game.totalFiles}
+              game={game}
               maxCount={maxGameCount}
-              size={game.totalSize}
               rank={i + 1}
             />
           ))}
           {remainingGames > 0 && (
-            <p className="text-xs text-stone-400 dark:text-slate-500 text-center pt-1">
+            <p className="text-xs text-stone-400 dark:text-slate-500 text-center pt-2">
               and {remainingGames} more game{remainingGames !== 1 ? "s" : ""}
             </p>
           )}
         </div>
-      </div>
+      </SectionCard>
 
       {/* Timeline */}
       {timelineSlice.length > 1 && (
-        <div className="p-4 rounded-xl bg-white dark:bg-[#161b22] border border-stone-200/80 dark:border-slate-700/50">
-          <SectionHeader
-            icon={<FireIcon className="w-4 h-4" />}
-            title="Capture Timeline"
-          />
+        <SectionCard
+          icon={<FireIcon className="w-4 h-4" />}
+          title="Capture Timeline"
+          delay={0.2}
+        >
           {stats.busiestMonth && (
-            <p className="text-xs text-stone-400 dark:text-slate-500 mb-3">
+            <p className="text-xs text-stone-400 dark:text-slate-500 mb-3 -mt-1">
               Peak:{" "}
-              <span className="font-semibold text-stone-600 dark:text-slate-300">
+              <span className="font-semibold text-nx">
                 {stats.busiestMonth.label}
               </span>{" "}
               with {stats.busiestMonth.count} captures
             </p>
           )}
-          <div className="flex gap-1 overflow-x-auto pb-1">
+          <div className="flex gap-px overflow-x-auto pb-1 -mx-1 px-1">
             {timelineSlice.map((m) => (
               <TimelineBar
                 key={`${m.year}-${m.month}`}
                 label={m.label}
                 count={m.count}
                 maxCount={maxMonthCount}
-                isMax={
-                  stats.busiestMonth !== null &&
-                  m.year === stats.busiestMonth.year &&
-                  m.month === stats.busiestMonth.month
-                }
+                isMax={m === stats.busiestMonth}
               />
             ))}
           </div>
@@ -336,7 +428,126 @@ export function CollectionStats({ gameGroups }: CollectionStatsProps) {
               {stats.timeline.length}
             </p>
           )}
-        </div>
+        </SectionCard>
+      )}
+
+      {/* When You Capture */}
+      {stats.totalFiles > 0 && (
+        <SectionCard
+          icon={<ClockIcon className="w-4 h-4" />}
+          title="When You Capture"
+          delay={0.25}
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Day of week */}
+            <div>
+              <p className="text-xs font-medium text-stone-500 dark:text-slate-400 uppercase tracking-wider mb-3">
+                Day of Week
+              </p>
+              <div className="flex gap-1">
+                {DAY_LABELS.map((label, i) => {
+                  const count = dowCounts[i]!;
+                  const isMax = count === maxDow && count > 0;
+                  return (
+                    <TimelineBar
+                      key={label}
+                      label={label}
+                      count={count}
+                      maxCount={maxDow}
+                      isMax={isMax}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Time of day */}
+            <div>
+              <p className="text-xs font-medium text-stone-500 dark:text-slate-400 uppercase tracking-wider mb-3">
+                Time of Day
+              </p>
+              <div className="space-y-2">
+                {TIME_PERIODS.map((period, i) => {
+                  const count = timePeriodCounts[i]!;
+                  const pct = maxTimePeriod > 0 ? (count / maxTimePeriod) * 100 : 0;
+                  const isMax = count === maxTimePeriod && count > 0;
+                  return (
+                    <div key={period.label}>
+                      <div className="flex items-center justify-between mb-1">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`text-xs font-medium ${
+                              isMax
+                                ? "text-nx font-semibold"
+                                : "text-stone-600 dark:text-slate-400"
+                            }`}
+                          >
+                            {period.label}
+                          </span>
+                          <span className="text-[10px] text-stone-400 dark:text-slate-500">
+                            {period.range}
+                          </span>
+                        </div>
+                        <span
+                          className={`text-xs font-mono tabular-nums ${
+                            isMax
+                              ? "text-nx font-bold"
+                              : "text-stone-400 dark:text-slate-500"
+                          }`}
+                        >
+                          {count.toLocaleString()}
+                        </span>
+                      </div>
+                      <div className="h-2 bg-stone-100 dark:bg-slate-800/80 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all duration-500 ${
+                            isMax
+                              ? "bg-gradient-to-r from-nx to-red-400"
+                              : "bg-nx/20 dark:bg-nx/15"
+                          }`}
+                          style={{ width: `${Math.max(pct, 2)}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </SectionCard>
+      )}
+
+      {/* Fun Facts */}
+      {stats.totalFiles > 0 && (
+        <SectionCard
+          icon={<SparklesIcon className="w-4 h-4" />}
+          title="Fun Facts"
+          delay={0.3}
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {funFacts.busiestDay && (
+              <FunFactCard
+                title="Most Active Day"
+                value={`${funFacts.busiestDay.count} captures`}
+                sub={formatDate(funFacts.busiestDay.date)}
+              />
+            )}
+            {funFacts.longestGap && (
+              <FunFactCard
+                title="Longest Break"
+                value={`${funFacts.longestGap.days} days`}
+                sub={`${formatDate(funFacts.longestGap.from)} to ${formatDate(funFacts.longestGap.to)}`}
+              />
+            )}
+            {funFacts.singleCaptureGames > 0 && (
+              <FunFactCard
+                title="One-Hit Wonders"
+                value={`${funFacts.singleCaptureGames} game${funFacts.singleCaptureGames !== 1 ? "s" : ""}`}
+                sub="with just 1 capture"
+              />
+            )}
+          </div>
+        </SectionCard>
       )}
     </div>
   );

--- a/src/components/DatabaseInfo.tsx
+++ b/src/components/DatabaseInfo.tsx
@@ -1,16 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { loadCaptureIdsMetadata } from "../utils/captureIds";
+import { formatDate } from "../utils/format";
 import type { CaptureIdsMetadata } from "../types";
-
-function formatDate(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 function formatNumber(num: number): string {
   return num.toLocaleString();
@@ -84,7 +76,7 @@ export function DatabaseInfo() {
               <div className="flex justify-between">
                 <dt>Generated</dt>
                 <dd className="font-medium text-stone-800 dark:text-slate-200">
-                  {formatDate(metadata.generatedAt)}
+                  {formatDate(new Date(metadata.generatedAt))}
                 </dd>
               </div>
             </dl>
@@ -117,7 +109,7 @@ export function DatabaseInfo() {
                       <span>Updated on</span>
                       <span>
                         {source.sourceUpdatedAt
-                          ? formatDate(source.sourceUpdatedAt)
+                          ? formatDate(new Date(source.sourceUpdatedAt))
                           : "Unknown"}
                       </span>
                     </div>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,6 +1,19 @@
+import { useState } from "react";
+import {
+  Squares2X2Icon,
+  ChartBarIcon,
+} from "@heroicons/react/24/solid";
 import type { GameGroup } from "../types";
 import { GameCard } from "./GameCard";
 import { SelectionButton } from "./SelectionButton";
+import { CollectionStats } from "./CollectionStats";
+
+type GalleryTab = "gallery" | "stats";
+
+const TABS: { value: GalleryTab; label: string; icon: typeof Squares2X2Icon }[] = [
+  { value: "gallery", label: "Gallery", icon: Squares2X2Icon },
+  { value: "stats", label: "Stats", icon: ChartBarIcon },
+];
 
 interface GalleryProps {
   gameGroups: GameGroup[];
@@ -21,6 +34,7 @@ export function Gallery({
   onSelectAll,
   onDeselectAll,
 }: GalleryProps) {
+  const [tab, setTab] = useState<GalleryTab>("gallery");
   const allSelected = selectedGames.size === gameGroups.length;
   const noneSelected = selectedGames.size === 0;
 
@@ -28,40 +42,70 @@ export function Gallery({
     <div>
       {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-4">
-        <p className="text-sm text-stone-500 dark:text-slate-400">
-          <span className="font-semibold text-stone-800 dark:text-slate-200">
-            {gameGroups.length}
-          </span>{" "}
-          {gameGroups.length === 1 ? "game" : "games"}
-          {" · "}
-          <span className="font-semibold text-stone-800 dark:text-slate-200">
-            {selectedFileCount}
-          </span>
-          {selectedFileCount !== totalFileCount &&
-            ` / ${totalFileCount}`}{" "}
-          files selected
-        </p>
-        <div className="flex gap-2">
-          <SelectionButton onClick={onSelectAll} disabled={allSelected}>
-            Select All
-          </SelectionButton>
-          <SelectionButton onClick={onDeselectAll} disabled={noneSelected}>
-            Deselect All
-          </SelectionButton>
+        <div className="flex items-center gap-3">
+          {/* Tab toggle */}
+          <div className="flex rounded-lg bg-stone-100 dark:bg-slate-800/80 p-0.5 border border-stone-200/50 dark:border-slate-700/30">
+            {TABS.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setTab(value)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+                  tab === value
+                    ? "bg-white dark:bg-slate-700 text-stone-800 dark:text-slate-200 shadow-sm"
+                    : "text-stone-500 dark:text-slate-400 hover:text-stone-700 dark:hover:text-slate-300"
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {tab === "gallery" && (
+            <p className="text-sm text-stone-500 dark:text-slate-400">
+              <span className="font-semibold text-stone-800 dark:text-slate-200">
+                {gameGroups.length}
+              </span>{" "}
+              {gameGroups.length === 1 ? "game" : "games"}
+              {" · "}
+              <span className="font-semibold text-stone-800 dark:text-slate-200">
+                {selectedFileCount}
+              </span>
+              {selectedFileCount !== totalFileCount &&
+                ` / ${totalFileCount}`}{" "}
+              files selected
+            </p>
+          )}
         </div>
+
+        {tab === "gallery" && (
+          <div className="flex gap-2">
+            <SelectionButton onClick={onSelectAll} disabled={allSelected}>
+              Select All
+            </SelectionButton>
+            <SelectionButton onClick={onDeselectAll} disabled={noneSelected}>
+              Deselect All
+            </SelectionButton>
+          </div>
+        )}
       </div>
 
-      {/* Grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-        {gameGroups.map((group) => (
-          <GameCard
-            key={group.gameName}
-            group={group}
-            selected={selectedGames.has(group.gameName)}
-            onToggle={() => onToggleGame(group.gameName)}
-          />
-        ))}
-      </div>
+      {/* Content */}
+      {tab === "gallery" ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          {gameGroups.map((group) => (
+            <GameCard
+              key={group.gameName}
+              group={group}
+              selected={selectedGames.has(group.gameName)}
+              onToggle={() => onToggleGame(group.gameName)}
+            />
+          ))}
+        </div>
+      ) : (
+        <CollectionStats gameGroups={gameGroups} />
+      )}
     </div>
   );
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,15 @@
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/utils/stats.test.ts
+++ b/src/utils/stats.test.ts
@@ -8,6 +8,7 @@ function makeParsedFile(
   month: number,
   day: number,
   size: number,
+  hour = 12,
 ): ParsedFile {
   return {
     file: { name, size } as File,
@@ -15,7 +16,7 @@ function makeParsedFile(
       year,
       month,
       day,
-      hour: 12,
+      hour,
       minute: 0,
       second: 0,
       captureId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
@@ -39,6 +40,11 @@ describe("computeStats", () => {
     expect(stats.busiestMonth).toBeNull();
     expect(stats.topGame).toBeNull();
     expect(stats.averageCapturesPerGame).toBe(0);
+    expect(stats.hourDistribution).toEqual(new Array(24).fill(0));
+    expect(stats.dayOfWeekDistribution).toEqual(new Array(7).fill(0));
+    expect(stats.funFacts.busiestDay).toBeNull();
+    expect(stats.funFacts.longestGap).toBeNull();
+    expect(stats.funFacts.singleCaptureGames).toBe(0);
   });
 
   it("should compute stats for a single game with images and videos", () => {
@@ -173,5 +179,128 @@ describe("computeStats", () => {
     expect(stats.gameStats[0]!.totalSize).toBe(51_000);
     expect(stats.gameStats[0]!.imageCount).toBe(1);
     expect(stats.gameStats[0]!.videoCount).toBe(1);
+  });
+
+  it("should compute hour distribution", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 0, 1, 100, 8),
+          makeParsedFile("b.jpg", 2023, 0, 2, 100, 8),
+          makeParsedFile("c.jpg", 2023, 0, 3, 100, 14),
+          makeParsedFile("d.jpg", 2023, 0, 4, 100, 22),
+          makeParsedFile("e.jpg", 2023, 0, 5, 100, 3),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.hourDistribution[8]).toBe(2);
+    expect(stats.hourDistribution[14]).toBe(1);
+    expect(stats.hourDistribution[22]).toBe(1);
+    expect(stats.hourDistribution[3]).toBe(1);
+    expect(stats.hourDistribution[0]).toBe(0);
+  });
+
+  it("should compute day-of-week distribution", () => {
+    // 2023-01-02 is a Monday (month 0 = January)
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 0, 2, 100), // Mon
+          makeParsedFile("b.jpg", 2023, 0, 3, 100), // Tue
+          makeParsedFile("c.jpg", 2023, 0, 7, 100), // Sat
+          makeParsedFile("d.jpg", 2023, 0, 8, 100), // Sun
+          makeParsedFile("e.jpg", 2023, 0, 9, 100), // Mon
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    // getDay(): 0=Sun, 1=Mon, 2=Tue, ...
+    expect(stats.dayOfWeekDistribution[0]).toBe(1); // Sun
+    expect(stats.dayOfWeekDistribution[1]).toBe(2); // Mon
+    expect(stats.dayOfWeekDistribution[2]).toBe(1); // Tue
+    expect(stats.dayOfWeekDistribution[6]).toBe(1); // Sat
+  });
+
+  it("should find the busiest day", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 0, 15, 100),
+          makeParsedFile("b.jpg", 2023, 0, 15, 100),
+          makeParsedFile("c.jpg", 2023, 0, 15, 100),
+          makeParsedFile("d.jpg", 2023, 0, 16, 100),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.funFacts.busiestDay?.count).toBe(3);
+    expect(stats.funFacts.busiestDay?.date).toEqual(new Date(2023, 0, 15));
+  });
+
+  it("should find the longest gap between captures", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 0, 1, 100),
+          makeParsedFile("b.jpg", 2023, 0, 5, 100),  // 4 day gap
+          makeParsedFile("c.jpg", 2023, 3, 1, 100),  // ~86 day gap
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.funFacts.longestGap).not.toBeNull();
+    expect(stats.funFacts.longestGap!.from).toEqual(new Date(2023, 0, 5));
+    expect(stats.funFacts.longestGap!.to).toEqual(new Date(2023, 3, 1));
+    expect(stats.funFacts.longestGap!.days).toBeGreaterThan(80);
+  });
+
+  it("should count single-capture games", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game A",
+        files: [makeParsedFile("a.jpg", 2023, 0, 1, 100)],
+      },
+      {
+        gameName: "Game B",
+        files: [
+          makeParsedFile("b1.jpg", 2023, 0, 1, 100),
+          makeParsedFile("b2.jpg", 2023, 0, 2, 100),
+        ],
+      },
+      {
+        gameName: "Game C",
+        files: [makeParsedFile("c.jpg", 2023, 0, 1, 100)],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.funFacts.singleCaptureGames).toBe(2);
+  });
+
+  it("should return null for longestGap with a single capture day", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [makeParsedFile("a.jpg", 2023, 0, 1, 100)],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.funFacts.longestGap).toBeNull();
   });
 });

--- a/src/utils/stats.test.ts
+++ b/src/utils/stats.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { computeStats } from "./stats";
+import type { GameGroup, ParsedFile } from "../types";
+
+function makeParsedFile(
+  name: string,
+  year: number,
+  month: number,
+  day: number,
+  size: number,
+): ParsedFile {
+  return {
+    file: { name, size } as File,
+    screenshot: {
+      year,
+      month,
+      day,
+      hour: 12,
+      minute: 0,
+      second: 0,
+      captureId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+      gameName: "Test",
+    },
+  };
+}
+
+describe("computeStats", () => {
+  it("should return zeroed stats for empty groups", () => {
+    const stats = computeStats([]);
+    expect(stats.totalFiles).toBe(0);
+    expect(stats.totalImages).toBe(0);
+    expect(stats.totalVideos).toBe(0);
+    expect(stats.totalSize).toBe(0);
+    expect(stats.totalGames).toBe(0);
+    expect(stats.firstCapture).toBeNull();
+    expect(stats.lastCapture).toBeNull();
+    expect(stats.gameStats).toEqual([]);
+    expect(stats.timeline).toEqual([]);
+    expect(stats.busiestMonth).toBeNull();
+    expect(stats.topGame).toBeNull();
+    expect(stats.averageCapturesPerGame).toBe(0);
+  });
+
+  it("should compute stats for a single game with images and videos", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "TETRIS 99",
+        files: [
+          makeParsedFile("screenshot1.jpg", 2023, 0, 15, 500_000),
+          makeParsedFile("screenshot2.jpg", 2023, 0, 20, 600_000),
+          makeParsedFile("video1.mp4", 2023, 1, 10, 5_000_000),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.totalFiles).toBe(3);
+    expect(stats.totalImages).toBe(2);
+    expect(stats.totalVideos).toBe(1);
+    expect(stats.totalSize).toBe(6_100_000);
+    expect(stats.totalGames).toBe(1);
+    expect(stats.averageCapturesPerGame).toBe(3);
+    expect(stats.topGame?.gameName).toBe("TETRIS 99");
+  });
+
+  it("should sort games by file count descending", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game A",
+        files: [makeParsedFile("a.jpg", 2023, 0, 1, 100)],
+      },
+      {
+        gameName: "Game B",
+        files: [
+          makeParsedFile("b1.jpg", 2023, 0, 1, 100),
+          makeParsedFile("b2.jpg", 2023, 0, 2, 100),
+          makeParsedFile("b3.mp4", 2023, 0, 3, 100),
+        ],
+      },
+      {
+        gameName: "Game C",
+        files: [
+          makeParsedFile("c1.jpg", 2023, 0, 1, 100),
+          makeParsedFile("c2.jpg", 2023, 0, 2, 100),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.gameStats[0]!.gameName).toBe("Game B");
+    expect(stats.gameStats[1]!.gameName).toBe("Game C");
+    expect(stats.gameStats[2]!.gameName).toBe("Game A");
+    expect(stats.topGame?.gameName).toBe("Game B");
+  });
+
+  it("should compute correct date range", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2020, 5, 15, 100),
+          makeParsedFile("b.jpg", 2023, 11, 25, 100),
+          makeParsedFile("c.jpg", 2021, 3, 1, 100),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.firstCapture).toEqual(new Date(2020, 5, 15));
+    expect(stats.lastCapture).toEqual(new Date(2023, 11, 25));
+  });
+
+  it("should build a sorted timeline of monthly buckets", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 2, 1, 100),
+          makeParsedFile("b.jpg", 2023, 2, 15, 100),
+          makeParsedFile("c.jpg", 2023, 0, 5, 100),
+          makeParsedFile("d.mp4", 2022, 11, 20, 100),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.timeline).toHaveLength(3);
+    // Should be sorted chronologically
+    expect(stats.timeline[0]!.label).toBe("Dec 2022");
+    expect(stats.timeline[0]!.count).toBe(1);
+    expect(stats.timeline[1]!.label).toBe("Jan 2023");
+    expect(stats.timeline[1]!.count).toBe(1);
+    expect(stats.timeline[2]!.label).toBe("Mar 2023");
+    expect(stats.timeline[2]!.count).toBe(2);
+  });
+
+  it("should identify the busiest month", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game",
+        files: [
+          makeParsedFile("a.jpg", 2023, 5, 1, 100),
+          makeParsedFile("b.jpg", 2023, 5, 2, 100),
+          makeParsedFile("c.jpg", 2023, 5, 3, 100),
+          makeParsedFile("d.jpg", 2023, 6, 1, 100),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.busiestMonth?.label).toBe("Jun 2023");
+    expect(stats.busiestMonth?.count).toBe(3);
+  });
+
+  it("should compute per-game size and media counts", () => {
+    const groups: GameGroup[] = [
+      {
+        gameName: "Game A",
+        files: [
+          makeParsedFile("a1.jpg", 2023, 0, 1, 1_000),
+          makeParsedFile("a2.mp4", 2023, 0, 1, 50_000),
+        ],
+      },
+    ];
+
+    const stats = computeStats(groups);
+
+    expect(stats.gameStats[0]!.totalSize).toBe(51_000);
+    expect(stats.gameStats[0]!.imageCount).toBe(1);
+    expect(stats.gameStats[0]!.videoCount).toBe(1);
+  });
+});

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -16,6 +16,12 @@ export interface MonthBucket {
   count: number;
 }
 
+export interface FunFacts {
+  busiestDay: { date: Date; count: number } | null;
+  longestGap: { days: number; from: Date; to: Date } | null;
+  singleCaptureGames: number;
+}
+
 export interface CollectionStats {
   totalFiles: number;
   totalImages: number;
@@ -29,7 +35,12 @@ export interface CollectionStats {
   busiestMonth: MonthBucket | null;
   topGame: GameStat | null;
   averageCapturesPerGame: number;
+  hourDistribution: number[];
+  dayOfWeekDistribution: number[];
+  funFacts: FunFacts;
 }
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 const MONTH_NAMES = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -48,6 +59,8 @@ export function computeStats(gameGroups: GameGroup[]): CollectionStats {
 
   const gameStats: GameStat[] = [];
   const monthMap = new Map<string, MonthBucket>();
+  const hourDist: number[] = new Array(24).fill(0);
+  const dayMap = new Map<number, { date: Date; count: number }>();
 
   for (const group of gameGroups) {
     let images = 0;
@@ -84,6 +97,15 @@ export function computeStats(gameGroups: GameGroup[]): CollectionStats {
           count: 1,
         });
       }
+
+      hourDist[f.screenshot.hour] = hourDist[f.screenshot.hour]! + 1;
+
+      const dayEntry = dayMap.get(dateKey);
+      if (dayEntry) {
+        dayEntry.count++;
+      } else {
+        dayMap.set(dateKey, { date: new Date(year, month, day), count: 1 });
+      }
     }
 
     totalImages += images;
@@ -113,6 +135,34 @@ export function computeStats(gameGroups: GameGroup[]): CollectionStats {
       ? timeline.reduce((max, m) => (m.count > max.count ? m : max))
       : null;
 
+  // Day-of-week distribution and busiest day from dayMap
+  const dowDist: number[] = new Array(7).fill(0);
+  let busiestDay: { date: Date; count: number } | null = null;
+  for (const entry of dayMap.values()) {
+    const dow = entry.date.getDay();
+    dowDist[dow] = dowDist[dow]! + entry.count;
+    if (!busiestDay || entry.count > busiestDay.count) {
+      busiestDay = entry;
+    }
+  }
+
+  // Longest gap between capture days
+  const sortedDays = Array.from(dayMap.values()).sort(
+    (a, b) => a.date.getTime() - b.date.getTime()
+  );
+  let longestGap: FunFacts["longestGap"] = null;
+  for (let i = 1; i < sortedDays.length; i++) {
+    const days = Math.round(
+      (sortedDays[i]!.date.getTime() - sortedDays[i - 1]!.date.getTime()) /
+        MS_PER_DAY
+    );
+    if (!longestGap || days > longestGap.days) {
+      longestGap = { days, from: sortedDays[i - 1]!.date, to: sortedDays[i]!.date };
+    }
+  }
+
+  const singleCaptureGames = gameStats.filter((g) => g.totalFiles === 1).length;
+
   return {
     totalFiles,
     totalImages,
@@ -127,5 +177,8 @@ export function computeStats(gameGroups: GameGroup[]): CollectionStats {
     topGame: gameStats[0] ?? null,
     averageCapturesPerGame:
       gameGroups.length > 0 ? Math.round(totalFiles / gameGroups.length) : 0,
+    hourDistribution: hourDist,
+    dayOfWeekDistribution: dowDist,
+    funFacts: { busiestDay, longestGap, singleCaptureGames },
   };
 }

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,131 @@
+import type { GameGroup } from "../types";
+import { IMAGE_EXT, VIDEO_EXT } from "../constants";
+
+export interface GameStat {
+  gameName: string;
+  totalFiles: number;
+  imageCount: number;
+  videoCount: number;
+  totalSize: number;
+}
+
+export interface MonthBucket {
+  year: number;
+  month: number;
+  label: string;
+  count: number;
+}
+
+export interface CollectionStats {
+  totalFiles: number;
+  totalImages: number;
+  totalVideos: number;
+  totalSize: number;
+  totalGames: number;
+  firstCapture: Date | null;
+  lastCapture: Date | null;
+  gameStats: GameStat[];
+  timeline: MonthBucket[];
+  busiestMonth: MonthBucket | null;
+  topGame: GameStat | null;
+  averageCapturesPerGame: number;
+}
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+export function computeStats(gameGroups: GameGroup[]): CollectionStats {
+  let totalImages = 0;
+  let totalVideos = 0;
+  let totalSize = 0;
+  let totalFiles = 0;
+  let minDateKey = Infinity;
+  let maxDateKey = -Infinity;
+  let minDate: Date | null = null;
+  let maxDate: Date | null = null;
+
+  const gameStats: GameStat[] = [];
+  const monthMap = new Map<string, MonthBucket>();
+
+  for (const group of gameGroups) {
+    let images = 0;
+    let videos = 0;
+    let size = 0;
+
+    for (const f of group.files) {
+      const name = f.file.name;
+      if (name.endsWith(IMAGE_EXT)) images++;
+      else if (name.endsWith(VIDEO_EXT)) videos++;
+
+      size += f.file.size;
+
+      const { year, month, day } = f.screenshot;
+      const dateKey = year * 10000 + month * 100 + day;
+      if (dateKey < minDateKey) {
+        minDateKey = dateKey;
+        minDate = new Date(year, month, day);
+      }
+      if (dateKey > maxDateKey) {
+        maxDateKey = dateKey;
+        maxDate = new Date(year, month, day);
+      }
+
+      const key = `${year}-${month}`;
+      const existing = monthMap.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        monthMap.set(key, {
+          year,
+          month,
+          label: `${MONTH_NAMES[month]} ${year}`,
+          count: 1,
+        });
+      }
+    }
+
+    totalImages += images;
+    totalVideos += videos;
+    totalSize += size;
+    totalFiles += group.files.length;
+
+    gameStats.push({
+      gameName: group.gameName,
+      totalFiles: group.files.length,
+      imageCount: images,
+      videoCount: videos,
+      totalSize: size,
+    });
+  }
+
+  // Sort games by file count descending
+  gameStats.sort((a, b) => b.totalFiles - a.totalFiles);
+
+  // Build sorted timeline
+  const timeline = Array.from(monthMap.values()).sort((a, b) =>
+    a.year !== b.year ? a.year - b.year : a.month - b.month
+  );
+
+  const busiestMonth =
+    timeline.length > 0
+      ? timeline.reduce((max, m) => (m.count > max.count ? m : max))
+      : null;
+
+  return {
+    totalFiles,
+    totalImages,
+    totalVideos,
+    totalSize,
+    totalGames: gameGroups.length,
+    firstCapture: minDate,
+    lastCapture: maxDate,
+    gameStats,
+    timeline,
+    busiestMonth,
+    topGame: gameStats[0] ?? null,
+    averageCapturesPerGame:
+      gameGroups.length > 0 ? Math.round(totalFiles / gameGroups.length) : 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a stats tab alongside the gallery view showing collection analytics: total captures, size, date range, top game, screenshots vs videos split, top games ranking, capture timeline, day-of-week/time-of-day distributions, and fun facts (busiest day, longest break, one-hit wonder games)
- Extract `computeStats()` utility with comprehensive tests (306 lines of test coverage)
- Add shared formatting helpers (`formatSize`, `formatDate`) to `utils/format.ts`

## Test plan
- [x] `pnpm build` passes (TypeScript + Vite)
- [x] `npx vitest run` — all 47 tests pass
- [x] Load screenshots folder and verify gallery still works
- [x] Switch to stats tab and verify all sections render correctly
- [ ] Test with empty collection (no crashes, graceful empty state)
- [ ] Test responsive layout on mobile/tablet breakpoints