### PR TITLE
Polish gallery tab with sorting and visual refinements

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Squares2X2Icon,
   ChartBarIcon,
+  ChevronUpDownIcon,
 } from "@heroicons/react/24/solid";
 import type { GameGroup } from "../types";
 import { GameCard } from "./GameCard";
@@ -9,11 +10,30 @@ import { SelectionButton } from "./SelectionButton";
 import { CollectionStats } from "./CollectionStats";
 
 type GalleryTab = "gallery" | "stats";
+type SortMode = "count" | "name" | "recent";
 
 const TABS: { value: GalleryTab; label: string; icon: typeof Squares2X2Icon }[] = [
   { value: "gallery", label: "Gallery", icon: Squares2X2Icon },
   { value: "stats", label: "Stats", icon: ChartBarIcon },
 ];
+
+const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+  { value: "count", label: "Most captures" },
+  { value: "name", label: "Name A\u2013Z" },
+  { value: "recent", label: "Most recent" },
+];
+
+function getLatestTimestamp(group: GameGroup): number {
+  let latest = 0;
+  for (const f of group.files) {
+    const s = f.screenshot;
+    // Encode as a single comparable integer (avoids Date allocation)
+    const ts = s.year * 10_000_000_000 + s.month * 100_000_000 + s.day * 1_000_000
+             + s.hour * 10_000 + s.minute * 100 + s.second;
+    if (ts > latest) latest = ts;
+  }
+  return latest;
+}
 
 interface GalleryProps {
   gameGroups: GameGroup[];
@@ -35,8 +55,36 @@ export function Gallery({
   onDeselectAll,
 }: GalleryProps) {
   const [tab, setTab] = useState<GalleryTab>("gallery");
+  const [sortMode, setSortMode] = useState<SortMode>("count");
   const allSelected = selectedGames.size === gameGroups.length;
   const noneSelected = selectedGames.size === 0;
+
+  const sortedGroups = useMemo(() => {
+    const sorted = [...gameGroups];
+    switch (sortMode) {
+      case "count":
+        sorted.sort((a, b) => b.files.length - a.files.length);
+        break;
+      case "name":
+        sorted.sort((a, b) => a.gameName.localeCompare(b.gameName));
+        break;
+      case "recent": {
+        const timestamps = new Map(sorted.map(g => [g, getLatestTimestamp(g)]));
+        sorted.sort((a, b) => timestamps.get(b)! - timestamps.get(a)!);
+        break;
+      }
+    }
+    return sorted;
+  }, [gameGroups, sortMode]);
+
+  const topGameName = useMemo(() => {
+    if (gameGroups.length <= 1) return null;
+    let top = gameGroups[0]!;
+    for (const g of gameGroups) {
+      if (g.files.length > top.files.length) top = g;
+    }
+    return top.gameName;
+  }, [gameGroups]);
 
   return (
     <div>
@@ -64,12 +112,12 @@ export function Gallery({
 
           {tab === "gallery" && (
             <p className="text-sm text-stone-500 dark:text-slate-400">
-              <span className="font-semibold text-stone-800 dark:text-slate-200">
+              <span className="font-display font-bold text-base text-stone-800 dark:text-slate-200">
                 {gameGroups.length}
               </span>{" "}
               {gameGroups.length === 1 ? "game" : "games"}
-              {" · "}
-              <span className="font-semibold text-stone-800 dark:text-slate-200">
+              {" \u00b7 "}
+              <span className="font-display font-bold text-base text-stone-800 dark:text-slate-200">
                 {selectedFileCount}
               </span>
               {selectedFileCount !== totalFileCount &&
@@ -80,7 +128,21 @@ export function Gallery({
         </div>
 
         {tab === "gallery" && (
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
+            {/* Sort control */}
+            <div className="relative">
+              <select
+                value={sortMode}
+                onChange={(e) => setSortMode(e.target.value as SortMode)}
+                className="appearance-none text-xs font-medium pl-3 pr-7 py-1.5 rounded-lg bg-stone-100 dark:bg-slate-800/80 text-stone-600 dark:text-slate-300 border border-stone-200/50 dark:border-slate-700/30 hover:bg-stone-200 dark:hover:bg-slate-700 transition-colors cursor-pointer focus:outline-none focus-visible:outline-2 focus-visible:outline-nx"
+              >
+                {SORT_OPTIONS.map(({ value, label }) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+              <ChevronUpDownIcon className="w-3.5 h-3.5 absolute right-2 top-1/2 -translate-y-1/2 text-stone-400 dark:text-slate-500 pointer-events-none" />
+            </div>
+
             <SelectionButton onClick={onSelectAll} disabled={allSelected}>
               Select All
             </SelectionButton>
@@ -93,12 +155,14 @@ export function Gallery({
 
       {/* Content — gallery grid stays mounted to preserve thumbnail cache */}
       <div className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 ${tab !== "gallery" ? "hidden" : ""}`}>
-        {gameGroups.map((group) => (
+        {sortedGroups.map((group, index) => (
           <GameCard
             key={group.gameName}
             group={group}
             selected={selectedGames.has(group.gameName)}
             onToggle={() => onToggleGame(group.gameName)}
+            index={index}
+            isTopGame={group.gameName === topGameName}
           />
         ))}
       </div>

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -1,14 +1,17 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CheckIcon, VideoCameraIcon } from "@heroicons/react/24/solid";
+import { CheckIcon, VideoCameraIcon, TrophyIcon } from "@heroicons/react/24/solid";
 import type { GameGroup } from "../types";
-import { IMAGE_EXT, VIDEO_EXT } from "../constants";
+import { IMAGE_EXT, VIDEO_EXT, SHORT_MONTH_NAMES } from "../constants";
 
 const SLIDESHOW_INTERVAL = 1500;
 const VIDEO_PREVIEW_DURATION = 5000;
 const CROSSFADE_MS = 150;
+const MAX_STAGGER_INDEX = 15;
+const STAGGER_DELAY_S = 0.04;
 const SUPPORTS_RVFC =
   typeof HTMLVideoElement !== "undefined" &&
   "requestVideoFrameCallback" in HTMLVideoElement.prototype;
+
 
 let _snapshotCanvas: HTMLCanvasElement | null = null;
 function snapshotVideoFrame(video: HTMLVideoElement): string | null {
@@ -24,9 +27,11 @@ interface GameCardProps {
   group: GameGroup;
   selected: boolean;
   onToggle: () => void;
+  index: number;
+  isTopGame: boolean;
 }
 
-export const GameCard = memo(function GameCard({ group, selected, onToggle }: GameCardProps) {
+export const GameCard = memo(function GameCard({ group, selected, onToggle, index, isTopGame }: GameCardProps) {
   const { thumbnailSource, imageCount, videoCount } = useMemo(() => {
     let thumbnail: { file: File; type: "image" | "video" } | null = null;
     let images = 0;
@@ -42,6 +47,18 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
       }
     }
     return { thumbnailSource: thumbnail, imageCount: images, videoCount: videos };
+  }, [group.files]);
+
+  const latestDate = useMemo(() => {
+    let latest: { year: number; month: number } | null = null;
+    for (const f of group.files) {
+      const s = f.screenshot;
+      if (!latest || s.year > latest.year || (s.year === latest.year && s.month > latest.month)) {
+        latest = { year: s.year, month: s.month };
+      }
+    }
+    if (!latest) return null;
+    return `${SHORT_MONTH_NAMES[latest.month]} ${latest.year}`;
   }, [group.files]);
 
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
@@ -228,20 +245,30 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
   const mediaClass = `w-full h-full object-cover absolute inset-0 z-[1] ${prevSnapshotUrl ? "transition-opacity duration-150" : ""} ${slideLoaded ? "opacity-100" : "opacity-0"}`;
   const prevMediaClass = "w-full h-full object-cover absolute inset-0 z-[1] pointer-events-none";
 
+  const staggerDelay = Math.min(index * STAGGER_DELAY_S, MAX_STAGGER_INDEX * STAGGER_DELAY_S);
+
   return (
     <button
       type="button"
       onClick={onToggle}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className={`relative rounded-xl overflow-hidden text-left transition-all duration-200 cursor-pointer bg-white dark:bg-[#161b22] hover:shadow-lg focus-visible:outline-2 focus-visible:outline-nx active:scale-[0.98] ${
+      className={`relative rounded-xl overflow-hidden text-left transition-all duration-200 cursor-pointer bg-white dark:bg-[#161b22] focus-visible:outline-2 focus-visible:outline-nx active:scale-[0.98] animate-fade-up ${
         selected
-          ? "ring-2 ring-nx shadow-md shadow-nx/10"
-          : "ring-1 ring-stone-200/80 dark:ring-slate-700/50 opacity-50 hover:opacity-75"
+          ? "ring-2 ring-nx shadow-lg shadow-nx/15 hover:shadow-xl hover:shadow-nx/20 hover:-translate-y-0.5"
+          : "ring-1 ring-stone-200/80 dark:ring-slate-700/50 hover:ring-stone-300 dark:hover:ring-slate-600 hover:shadow-lg hover:-translate-y-0.5"
       }`}
+      style={{ animationDelay: `${staggerDelay}s` }}
     >
+      {/* Top game gradient accent */}
+      {isTopGame && (
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-amber-400 via-amber-300 to-amber-400 z-[3]" />
+      )}
+
       {/* Thumbnail / Slideshow */}
-      <div className="aspect-video bg-stone-100 dark:bg-slate-800/80 relative overflow-hidden">
+      <div className={`aspect-video bg-stone-100 dark:bg-slate-800/80 relative overflow-hidden transition-[filter] duration-300 ${
+        selected ? "" : "grayscale-[0.5] brightness-[0.8]"
+      }`}>
         {/* Previous slide snapshot (holds during transition to prevent flash) */}
         {isHovering && prevSnapshotUrl && (
           <img src={prevSnapshotUrl} alt="" className={prevMediaClass} />
@@ -281,22 +308,35 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
             loading="lazy"
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <VideoCameraIcon className="w-8 h-8 text-stone-300 dark:text-slate-600" />
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-stone-100 via-stone-50 to-stone-200 dark:from-slate-800 dark:via-slate-800/80 dark:to-slate-700">
+            <div className="flex flex-col items-center gap-1.5 px-3">
+              <VideoCameraIcon className="w-6 h-6 text-stone-300 dark:text-slate-600" />
+              <p className="text-[10px] font-display font-semibold text-stone-300 dark:text-slate-600 text-center leading-tight truncate max-w-full">
+                {group.gameName}
+              </p>
+            </div>
           </div>
         )}
 
         {/* Slideshow dots (up to 12 files) */}
         {isHovering && fileCount > 1 && fileCount <= 12 && (
-          <div className="absolute bottom-1.5 left-1/2 -translate-x-1/2 flex gap-1 z-[2]">
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1 z-[2] bg-black/30 backdrop-blur-sm rounded-full px-2 py-1">
             {group.files.map((_, i) => (
               <div
                 key={i}
-                className={`w-1 h-1 rounded-full transition-colors ${
+                className={`w-1.5 h-1.5 rounded-full transition-colors ${
                   i === slideIndex ? "bg-white" : "bg-white/40"
                 }`}
               />
             ))}
+          </div>
+        )}
+
+        {/* Top game badge */}
+        {isTopGame && (
+          <div className="absolute top-2 left-2 z-[2] flex items-center gap-1 bg-amber-400/90 backdrop-blur-sm text-amber-900 rounded-md px-1.5 py-0.5 shadow-sm">
+            <TrophyIcon className="w-3 h-3" />
+            <span className="text-[10px] font-bold uppercase tracking-wide">#1</span>
           </div>
         )}
 
@@ -308,7 +348,7 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
               : "bg-white/80 dark:bg-[#161b22]/80 border border-stone-300 dark:border-slate-600"
           }`}
         >
-          {selected && <CheckIcon className="w-3.5 h-3.5" />}
+          {selected && <CheckIcon className="w-3.5 h-3.5 animate-check-bounce" />}
         </div>
       </div>
 
@@ -320,13 +360,20 @@ export const GameCard = memo(function GameCard({ group, selected, onToggle }: Ga
         >
           {group.gameName}
         </p>
-        <p className="text-xs text-stone-400 dark:text-slate-500 mt-0.5">
-          {imageCount > 0 &&
-            `${imageCount} screenshot${imageCount !== 1 ? "s" : ""}`}
-          {imageCount > 0 && videoCount > 0 && " · "}
-          {videoCount > 0 &&
-            `${videoCount} video${videoCount !== 1 ? "s" : ""}`}
-        </p>
+        <div className="flex items-center justify-between mt-0.5">
+          <p className="text-xs text-stone-400 dark:text-slate-500">
+            {imageCount > 0 &&
+              `${imageCount} screenshot${imageCount !== 1 ? "s" : ""}`}
+            {imageCount > 0 && videoCount > 0 && " \u00b7 "}
+            {videoCount > 0 &&
+              `${videoCount} video${videoCount !== 1 ? "s" : ""}`}
+          </p>
+          {latestDate && (
+            <p className="text-[10px] text-stone-300 dark:text-slate-600 font-mono tabular-nums shrink-0 ml-2">
+              {latestDate}
+            </p>
+          )}
+        </div>
       </div>
     </button>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,13 @@ export const VALIDATION = {
   MAX_SECOND: 59,
 } as const;
 
-// Month names for folder-structure formatting
+// Short month names (0-indexed, matching JS Date months)
+export const SHORT_MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+] as const;
+
+// Full month names for folder-structure formatting
 export const MONTH_NAMES = [
   "January",
   "February",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,7 @@
 
   --animate-fade-up: fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-shimmer: shimmer 2s linear infinite;
+  --animate-check-bounce: check-bounce 0.2s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
 @keyframes fade-up {
@@ -55,6 +56,18 @@ html {
     rgba(230, 0, 18, 0.08),
     transparent 70%
   );
+}
+
+@keyframes check-bounce {
+  from {
+    transform: scale(0);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  to {
+    transform: scale(1);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,5 +1,5 @@
 import type { GameGroup } from "../types";
-import { IMAGE_EXT, VIDEO_EXT } from "../constants";
+import { IMAGE_EXT, VIDEO_EXT, SHORT_MONTH_NAMES } from "../constants";
 
 export interface GameStat {
   gameName: string;
@@ -42,10 +42,6 @@ export interface CollectionStats {
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
-const MONTH_NAMES = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
 
 export function computeStats(gameGroups: GameGroup[]): CollectionStats {
   let totalImages = 0;
@@ -93,7 +89,7 @@ export function computeStats(gameGroups: GameGroup[]): CollectionStats {
         monthMap.set(key, {
           year,
           month,
-          label: `${MONTH_NAMES[month]} ${year}`,
+          label: `${SHORT_MONTH_NAMES[month]} ${year}`,
           count: 1,
         });
       }


### PR DESCRIPTION
## Summary
- Add sort dropdown (most captures, name A–Z, most recent) to the gallery header
- Staggered fade-up entrance animation for cards (capped at 15 for snappy feel)
- Reworked deselected state: grayscale + dimmed thumbnail instead of full-card opacity
- Hover lift effect (`-translate-y-0.5`) on all cards
- Enlarged slideshow dots (6px) with dark backdrop pill for readability
- Most recent capture date (e.g. "Mar 2024") shown per card
- Top game gets a golden accent bar and `#1` trophy badge
- Improved empty thumbnail placeholder with gradient + game name
- Checkbox bounce animation on selection
- Display font + bold for game/file counts in header
- Extracted `SHORT_MONTH_NAMES` constant to avoid duplication between stats and cards
- Precomputed timestamps with integer encoding for efficient "most recent" sorting

## Test plan
- [ ] Load screenshots and verify staggered card entrance animation
- [ ] Toggle card selection — confirm grayscale/color transition and checkbox bounce
- [ ] Hover cards — verify lift effect and slideshow dot backdrop
- [ ] Test all three sort modes (count, name, recent)
- [ ] Verify top game badge appears on the game with the most captures
- [ ] Check dark mode for all new visual elements
- [ ] Confirm cards with only videos show the improved placeholder